### PR TITLE
Docker対応する

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# OS / IDE関連
+.DS_Store
+.idea
+*.iml
+
+# Git
+.git
+.gitignore
+
+# ビルド成果物
+target/
+*.jar
+
+# 環境ファイル
+.env
+*.log
+
+# Docker自身
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Maven + JDK 17 のビルドステージ
+FROM maven:3.9.6-eclipse-temurin AS builder
+WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
+
+# JRE 17 の実行ステージ（alpineではなくDebianベースで安定）
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
+EXPOSE 8082
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>webapp</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>webapp</name>
+    <description>Spring Boot Web App</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=tk-bot
-server.port=8082
+server.port=8082 # ローカルホストは8082を指定

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=tk-bot
+server.port=8082


### PR DESCRIPTION
## 概要
Dockerでビルドする？というのか？に対応した

## やったこと
### 1. ディレクトリに必要ファイルを追加
以下のファイルをプロジェクトのルートディレクトリに追加
```
Pom.xml
Dockerfile
.dockerignore
```

### 2. ポート番号を8082に指定
```
server.port=8082
```

## 動かすには

### 1. Docker イメージをビルド

プロジェクトのルートディレクトリで以下実行
```
docker build -t tk-bot .
```

### 2. Docker コンテナを実行

プロジェクトのルートディレクトリで以下実行
```
docker run -p 8082:8082 tk-bot
```

### 3. アクセスできるか確認
ブラウザでローカルホストの8082にアクセス
```
http://localhost:8082 にアクセス
```