### PR TITLE
コメントのせいでビルドが通らなくなっていたバグ

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=tk-bot
-server.port=8082 # ローカルホストは8082を指定
+server.port=8082


### PR DESCRIPTION
## 対応内容
```
tk-bot/src/main/resources/application.properties
```
にコメントを入れたらビルドが通らなくなっていたのでコメントを消す

このコミット
https://github.com/takuro-uejo/tk-bot/pull/1/commits/0cd9d9bca0e115768fb9db3faef3815b916d1702
のデグレ