### PR TITLE
RESTの仕組みを共存させる、webhookのルーティングを追加する

### DIFF
--- a/src/main/java/com/example/demo/LineBotController.java
+++ b/src/main/java/com/example/demo/LineBotController.java
@@ -4,13 +4,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/linebot")
+@RequestMapping("/webhook")
 public class LineBotController {
     @PostMapping
     public ResponseEntity<String> webhook(@RequestBody String payload) {
         // LINEからのリクエスト（JSON）を受け取ってログに出力
         System.out.println("LINE Webhook 受信: " + payload);
-
         // 仮の応答（LINEの要件：200 OKを返す）
         return ResponseEntity.ok("OK");
     }

--- a/src/main/java/com/example/demo/LineBotController.java
+++ b/src/main/java/com/example/demo/LineBotController.java
@@ -1,0 +1,17 @@
+package com.example.demo;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/linebot")
+public class LineBotController {
+    @PostMapping
+    public ResponseEntity<String> webhook(@RequestBody String payload) {
+        // LINEからのリクエスト（JSON）を受け取ってログに出力
+        System.out.println("LINE Webhook 受信: " + payload);
+
+        // 仮の応答（LINEの要件：200 OKを返す）
+        return ResponseEntity.ok("OK");
+    }
+}

--- a/src/main/java/com/example/demo/PageController.java
+++ b/src/main/java/com/example/demo/PageController.java
@@ -2,11 +2,21 @@ package com.example.demo;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @Controller
 public class PageController {
     @GetMapping("/test")
     public String showTestPage() {
-        return "test";  // templates/test.html を探して返す
+        return "test"; // templates/test.html を探して返す
+    }
+
+    @PostMapping("/webhook")
+    public String handleWebhook(@RequestBody String requestBody, @RequestHeader("X-Line-Signature") String signature) {
+        // LINEbotからのリクエストはこのパスで拾う
+        // 今はテスト的にOKを返す
+        return "OK";
     }
 }

--- a/src/main/java/com/example/demo/PageController.java
+++ b/src/main/java/com/example/demo/PageController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public class PageController {
     @GetMapping("/test")
     public String showTestPage() {
+        System.out.println("GET /test.");
         return "test"; // templates/test.html を探して返す
     }
 
@@ -17,6 +18,7 @@ public class PageController {
     public String handleWebhook(@RequestBody String requestBody, @RequestHeader("X-Line-Signature") String signature) {
         // LINEbotからのリクエストはこのパスで拾う
         // 今はテスト的にOKを返す
+        System.out.println("POST /webhook.");
         return "OK";
     }
 }

--- a/src/main/java/com/example/demo/PageController.java
+++ b/src/main/java/com/example/demo/PageController.java
@@ -2,9 +2,6 @@ package com.example.demo;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 @Controller
 public class PageController {
@@ -12,13 +9,5 @@ public class PageController {
     public String showTestPage() {
         System.out.println("GET /test.");
         return "test"; // templates/test.html を探して返す
-    }
-
-    @PostMapping("/webhook")
-    public String handleWebhook(@RequestBody String requestBody, @RequestHeader("X-Line-Signature") String signature) {
-        // LINEbotからのリクエストはこのパスで拾う
-        // 今はテスト的にOKを返す
-        System.out.println("POST /webhook.");
-        return "OK";
     }
 }


### PR DESCRIPTION
## 概要
webhookのルーティングの追加

## 対応内容
LINEbotからのメッセージ着弾を捌くパスを作っておく
```
https://tk-bot.uejo.app/webhook
```
をLINE Developerのコンソールから登録すると、LINEBotに何かが送られたときにこのアプリが動くようになる

あといるかわからんけど色々ログ出しをしておく

## 備考
今のところ、常に成功のステータスコード（200）を返すように実装しているので、デプロイしたらLINE Developerのコンソールから疎通確認が取れるはず

`@Controller`は静的なHTMLをただ返すだけ、`@RestController`はBotとかAPIとか高度な用途に使えるみたい

いちおうAPI Testerでも確認
ちゃんと200を返せてるのと、BodyにOKを入れられている
<img width="647" alt="スクリーンショット 2025-05-13 19 06 28" src="https://github.com/user-attachments/assets/ceb78708-ef41-41d7-aa7d-a575bc3029a5" />

## 次やること
1. デプロイ作業する（これがマージされたあとに兄がやる）
2. tk-botと疎通確認する（デプロイが終わったあとに弟がやる）

### tk-botの疎通確認って何やるの？
初手、tk-botのLINE Developerで、この赤枠のWebhook URLのところ、
<img width="1507" alt="スクリーンショット 2025-05-13 19 09 03" src="https://github.com/user-attachments/assets/e62f4b5e-7741-4fd1-982e-db2d3d892b89" />

Edit して
```
https://tk-bot.uejo.app/webhook
```
こいつを入れて、Verify する。
Verifyをしたときに成功っぽい表示になったら、疎通成功。