### PR TITLE
デバッグ用のルーティング追加

### DIFF
--- a/src/main/java/com/example/tkbot/controller/DebugPostRequestController.java
+++ b/src/main/java/com/example/tkbot/controller/DebugPostRequestController.java
@@ -1,0 +1,30 @@
+package com.example.tkbot.controller;
+
+import com.example.tkbot.model.DebugPostRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/debug")
+public class DebugPostRequestController {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @PostMapping
+    public ResponseEntity<String> handleDebugPost(@RequestBody String payload) {
+        try {
+            DebugPostRequest request = objectMapper.readValue(payload, DebugPostRequest.class);
+            String message = request.getTestmessage();
+            System.out.println("DEBUG: 受け取ったメッセージ → " + message);
+            return ResponseEntity.ok("DEBUG: 受け取ったメッセージ → " + message);
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println("DEBUG: JSONパースに失敗しました: " + e.getMessage());
+            return ResponseEntity
+            .badRequest()
+            .body("DEBUG: JSONパースに失敗しました: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/tkbot/model/DebugPostRequest.java
+++ b/src/main/java/com/example/tkbot/model/DebugPostRequest.java
@@ -1,0 +1,10 @@
+package com.example.tkbot.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DebugPostRequest {
+    private String testmessage;
+}


### PR DESCRIPTION
## 概要
デバッグ用のルーティング（Talend API TesterとかVScodeとかでログを見れるやつ）を作る

## 使い方
### 1. 初手、ローカル（port8082で立ち上がるように作っている）でtk-botを立ち上げる

念のため、ここを参照↓↓↓
https://github.com/takuro-uejo/tk-bot?tab=readme-ov-file#%E3%83%87%E3%83%90%E3%83%83%E3%82%B0%E6%96%B9%E6%B3%95%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB

もしくはターミナルから毎回コマンドうつの面倒なので、VScodeからビルド・停止できるようにすると便利だった！
<img width="1082" alt="スクリーンショット 2025-05-23 10 31 44" src="https://github.com/user-attachments/assets/bd85e5fe-7e95-476e-9bc7-4f5a1f4fd790" />

VScode × Javaの環境構築の方法はこれとか、
https://note.com/liber_grp/n/n88f3f0a6fdf1#19d1caf3-5747-4e90-aec1-0b438a83da80
うまくいかなかったらチャトピに聞くか、他ググってみるかで見てみると吉

### 2. Talend API Testerで文字列だけを送るPOSTリクエスト送信！

こんな感じでローカルホストで起動しているtk-botに向けてリクエスト送る（赤枠のSendボタンを押したらリクエストできる）
<img width="1506" alt="スクリーンショット 2025-05-23 10 37 51" src="https://github.com/user-attachments/assets/412dcec9-8bd5-4972-871a-d904058d01a8" />
```
リクエストメソッド：POST
Content-Type：application/json
エンドポイント：http://localhost:8082/debug

リクエストボディ：
{
  "testmessage": "ほげほげ"
}
```

### 3. 結果を見て試行錯誤しながら作ってゆく

あとは、VScodeのコンソール（赤枠部分）
<img width="1220" alt="スクリーンショット 2025-05-23 10 42 08" src="https://github.com/user-attachments/assets/9355a8db-4304-4938-9ecb-3feb54317c1b" />
でも、

Talend API Testerの結果のとこ（赤枠部分）
<img width="1159" alt="スクリーンショット 2025-05-23 10 41 20" src="https://github.com/user-attachments/assets/73230161-c101-4ef9-9d77-c9a84c3c8159" />
でも結果（出力ログも返したレスポンスもどっちも）が見れるから、見ながら色々変えたりしながらやる

こっち
```
System.out.println("DEBUG: 受け取ったメッセージ → " + message);
```
は、ログを出すためのコード
VSCodeやターミナルで起動したときに、コンソール側にログ出力がされるのは、このコードがあるから

こっち
```
return ResponseEntity.ok("DEBUG: 受け取ったメッセージ → " + message);
```
は、クライアントに対してレスポンスを返しているコード
Talend API Testerの結果のところでレスポンスが見られるのは、このコードがあるから

ソースコードを追っかけながらどこで何やってる？を見ながら進めていけばおけ！